### PR TITLE
refactor(schema): make year relation optional to support safe migration

### DIFF
--- a/app/api/medals/route.ts
+++ b/app/api/medals/route.ts
@@ -7,9 +7,14 @@ export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url)
   const year = parseInt(searchParams.get('year') || '2022', 10)
 
+  console.log('Fetching medals for year:', year)
   try {
     const medals = await prisma.medal.findMany({
-      where: { year },
+      where: {
+        year: {
+          value: year,
+        },
+      },
       include: { country: true },
     })
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,11 +14,18 @@ model Country {
   medals  Medal[]
 }
 
+model Year {
+  id     Int     @id @default(autoincrement())
+  value  Int     @unique
+  medals Medal[] // relation
+}
+
 model Medal {
-  id         Int     @id @default(autoincrement())
-  year       Int     // e.g. 2022
-  type       String  // 'gold' | 'silver' | 'bronze'
-  count      Int     // how many medals of that type
-  country    Country @relation(fields: [countryId], references: [id])
-  countryId  Int
+  id        Int      @id @default(autoincrement())
+  type      String
+  count     Int
+  country   Country  @relation(fields: [countryId], references: [id])
+  countryId Int
+  year      Year?    @relation(fields: [yearValue], references: [value])
+  yearValue Int?
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -4,30 +4,32 @@ import path from 'path'
 
 const prisma = new PrismaClient()
 const MEDAL_DATA_PATH = path.join(__dirname, '../public/medals.json')
-const YEAR = 2022
 
 async function main() {
   const raw = fs.readFileSync(MEDAL_DATA_PATH, 'utf-8')
   const countries: { code: string; gold: number; silver: number; bronze: number }[] =
     JSON.parse(raw)
 
-  for (const { code, gold, silver, bronze } of countries) {
-    const country = await prisma.country.upsert({
-      where: { code },
-      update: {},
-      create: { code, name: code },
-    })
+  const years = await prisma.year.findMany()
 
-    await prisma.medal.createMany({
-      data: [
-        { countryId: country.id, year: YEAR, type: 'gold', count: gold },
-        { countryId: country.id, year: YEAR, type: 'silver', count: silver },
-        { countryId: country.id, year: YEAR, type: 'bronze', count: bronze },
-      ],
-    })
+  for (const year of years) {
+    for (const { code, gold, silver, bronze } of countries) {
+      const country = await prisma.country.upsert({
+        where: { code },
+        update: {},
+        create: { code, name: code },
+      })
+
+      await prisma.medal.createMany({
+        data: [
+          { countryId: country.id, yearValue: year.id, type: 'gold', count: gold },
+          { countryId: country.id, yearValue: year.id, type: 'silver', count: silver },
+          { countryId: country.id, yearValue: year.id, type: 'bronze', count: bronze },
+        ],
+      })
+    }
+    console.log(`✅ Seeded ${countries.length} countries and their medals for ${year.value}`)
   }
-
-  console.log(`✅ Seeded ${countries.length} countries and their medals for ${YEAR}`)
 }
 
 main()

--- a/scripts/testDb.ts
+++ b/scripts/testDb.ts
@@ -4,7 +4,7 @@ const prisma = new PrismaClient()
 
 async function main() {
   const medals = await prisma.medal.findMany({
-    where: { year: 2022 },
+    where: { yearValue: 2022 },
     include: { country: true },
     orderBy: [{ country: { code: 'asc' } }, { type: 'asc' }],
   })


### PR DESCRIPTION
## Summary

This PR merges the `feature` branch into `main`, introducing the following enhancements:

### UI Features
- Responsive medal table with flag icons
- Column sorting with asc/desc toggle and visual indicators
- Keyboard navigation on sortable headers
- Dark mode with Tailwind and shadcn
- Accessible year dropdown selector

### Data Layer
- Switched from JSON to SQLite + Prisma for medals
- REST API `/api/medals` with support for year-based filtering
- Fully typed and test-covered `useMedalData` hook

### Developer Experience
- Added Vitest for unit testing hooks
- MSW mock server for API mocking
- JSDOM test environment for hook compatibility
- Pre-commit hooks for formatting, linting, and test validation

---

## Test Instructions

1. `pnpm install`
2. `pnpm prisma migrate reset`
3. `pnpm test`
4. `pnpm dev`

---

## Notes

- Production deployment handled via Vercel with Prisma considerations
- All known issues addressed in this branch